### PR TITLE
Workaround for libglu/imx-gpu-viv SDK compatibility

### DIFF
--- a/recipes-support/librealsense/librealsense2_2.50.0.bb
+++ b/recipes-support/librealsense/librealsense2_2.50.0.bb
@@ -8,17 +8,11 @@ DEPENDS = "\
     udev \
 "
 
-DEPENDS += "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'libpng libglu glfw gtk+3', '', d)}"
-
 RDEPENDS:${PN} = "\
     bash \
 "
 RDEPENDS:${PN}-examples += "\
     ${PN} \
-"
-RDEPENDS:${PN}-graphical-examples += "\
-    ${PN} \
-    libgl-mesa \
 "
 
 RRECOMMENDS:${PN} += "kernel-module-uvcvideo"
@@ -35,8 +29,8 @@ EXTRA_OECMAKE += " \
     -DBUILD_SHARED_LIBS:BOOL=ON \
     -DBUILD_WITH_TM2:BOOL=ON \
     -DBUILD_EXAMPLES:BOOL=ON \
-    -DBUILD_GRAPHICAL_EXAMPLES:BOOL=${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'ON', 'OFF', d)} \
-    -DBUILD_GLSL_EXTENSIONS:BOOL=${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'ON', 'OFF', d)} \
+    -DBUILD_GRAPHICAL_EXAMPLES:BOOL=OFF \
+    -DBUILD_GLSL_EXTENSIONS:BOOL=OFF \
 "
 
 PACKAGES += "\
@@ -69,27 +63,6 @@ FILES:${PN}-examples = "\
     ${bindir}/rs-pose-and-image \
     ${bindir}/rs-pose-predict \
     ${bindir}/rs-save-to-disk \
-"
-
-FILES:${PN}-graphical-examples = "\
-    ${bindir}/rs-align \
-    ${bindir}/rs-align-advanced \
-    ${bindir}/rs-ar-advanced \
-    ${bindir}/rs-ar-basic \
-    ${bindir}/rs-callback \
-    ${bindir}/rs-capture \
-    ${bindir}/rs-gl \
-    ${bindir}/rs-hdr \
-    ${bindir}/rs-measure \
-    ${bindir}/rs-motion \
-    ${bindir}/rs-multicam \
-    ${bindir}/rs-pointcloud \
-    ${bindir}/rs-post-processing \
-    ${bindir}/rs-record-playback \
-    ${bindir}/rs-sensor-control \
-    ${bindir}/rs-software-device \
-    ${bindir}/rs-tracking-and-depth \
-    ${bindir}/rs-trajectory \
 "
 
 FILES:${PN}-tools = "\


### PR DESCRIPTION
- Remove librealsense2-graphical-examples
- Remove opengl related dependencies